### PR TITLE
need to cast other column's fields to text for non-text types to work

### DIFF
--- a/bbox-feature-server/src/datasource/postgis.rs
+++ b/bbox-feature-server/src/datasource/postgis.rs
@@ -265,10 +265,10 @@ impl CollectionSource for PgCollectionSource {
                     // detect if value has wildcards
                     if self.other_columns.get(key).is_some() {
                         let val = if val.rfind('*').is_some() {
-                            separated.push(format!("{key} like "));
+                            separated.push(format!("{key}::text like "));
                             val.replace('*', "%")
                         } else {
-                            separated.push(format!("{key}="));
+                            separated.push(format!("{key}::text="));
                             val.to_string()
                         };
                         separated.push_bind_unseparated(val);


### PR DESCRIPTION
If a queryable_field is a non-text column in a pg db, the query will fail with an error like

"operator does not exist: integer = text"

This patch casts all columns to text.