### PR TITLE
Add queryables route for Features API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5387,6 +5387,7 @@ dependencies = [
  "atoi",
  "byteorder",
  "bytes 1.6.0",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -5469,6 +5470,7 @@ dependencies = [
  "bitflags 2.5.0",
  "byteorder",
  "bytes 1.6.0",
+ "chrono",
  "crc",
  "digest 0.10.7",
  "dotenvy",
@@ -5510,6 +5512,7 @@ dependencies = [
  "base64 0.21.7",
  "bitflags 2.5.0",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -5545,6 +5548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
 dependencies = [
  "atoi",
+ "chrono",
  "flume 0.11.0",
  "futures-channel",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rust-embed = { version = "6.8.1", features = ["compression"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 serde_urlencoded = "0.7.1"
-sqlx = { version = "0.7.0", default-features = false, features = [ "runtime-tokio-rustls", "sqlite", "postgres" ] }
+sqlx = { version = "0.7.0", default-features = false, features = [ "runtime-tokio-rustls", "sqlite", "postgres", "chrono" ] }
 tempfile = "3.8.1"
 thiserror = "1.0.31"
 tokio = { version = "1.19.2" }

--- a/bbox-core/src/ogcapi.rs
+++ b/bbox-core/src/ogcapi.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::collections::HashMap;
 
 #[derive(Debug, Serialize)]
 /// <http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_api_landing_page>
@@ -116,6 +117,45 @@ pub struct CoreFeature {
     pub id: Option<String>, // string or integer
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub links: Vec<ApiLink>,
+}
+
+#[derive(Debug, Serialize)]
+/// <https://docs.ogc.org/DRAFTS/19-079r1.html#queryables>
+pub struct Queryables {
+    #[serde(rename = "type")]
+    pub type_: String, // Feature
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(rename = "$id")]
+    pub id: String,
+    #[serde(rename = "$schema")]
+    pub schema: String,
+    pub properties: HashMap<String, QueryableProperty>,
+}
+
+#[derive(Debug, Serialize)]
+/// <https://docs.ogc.org/DRAFTS/19-079r1.html#queryables>
+pub struct QueryableProperty {
+    #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub type_: Option<QueryableType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+/// <https://docs.ogc.org/DRAFTS/19-079r1.html#queryables>
+pub enum QueryableType {
+    #[serde(rename = "string")]
+    String,
+    #[serde(rename = "integer")]
+    Integer,
+    #[serde(rename = "number")]
+    Number,
+    #[serde(rename = "boolean")]
+    Bool,
 }
 
 pub type GeoJsonProperties = serde_json::value::Value;

--- a/bbox-core/src/ogcapi.rs
+++ b/bbox-core/src/ogcapi.rs
@@ -156,6 +156,8 @@ pub enum QueryableType {
     Number,
     #[serde(rename = "boolean")]
     Bool,
+    #[serde(rename = "datetime")]
+    Datetime,
 }
 
 pub type GeoJsonProperties = serde_json::value::Value;

--- a/bbox-feature-server/src/datasource/gpkg.rs
+++ b/bbox-feature-server/src/datasource/gpkg.rs
@@ -247,6 +247,10 @@ impl CollectionSource for GpkgCollectionSource {
             Ok(None)
         }
     }
+
+    async fn queryables(&self, _collection_id: &str) -> Result<Option<Queryables>> {
+        Ok(None)
+    }
 }
 
 fn row_to_feature(row: &SqliteRow, table_info: &GpkgCollectionSource) -> Result<CoreFeature> {

--- a/bbox-feature-server/src/datasource/mod.rs
+++ b/bbox-feature-server/src/datasource/mod.rs
@@ -6,7 +6,7 @@ use crate::filter_params::FilterParams;
 use crate::inventory::FeatureCollection;
 use async_trait::async_trait;
 use bbox_core::config::{DatasourceCfg, NamedDatasourceCfg};
-use bbox_core::ogcapi::{CoreExtent, CoreFeature};
+use bbox_core::ogcapi::{CoreExtent, CoreFeature, Queryables};
 use bbox_core::NamedObjectStore;
 use dyn_clone::{clone_trait_object, DynClone};
 use std::env;
@@ -32,6 +32,7 @@ pub trait AutoscanCollectionDatasource {
 pub trait CollectionSource: DynClone + Sync + Send {
     async fn items(&self, filter: &FilterParams) -> Result<ItemsResult>;
     async fn item(&self, collection_id: &str, feature_id: &str) -> Result<Option<CoreFeature>>;
+    async fn queryables(&self, collection_id: &str) -> Result<Option<Queryables>>;
 }
 
 clone_trait_object!(CollectionSource);

--- a/bbox-feature-server/src/datasource/postgis.rs
+++ b/bbox-feature-server/src/datasource/postgis.rs
@@ -576,6 +576,7 @@ async fn get_column_info(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bbox_core::ogcapi::QueryableType;
     use std::collections::HashMap;
     use test_log::test;
 
@@ -609,7 +610,7 @@ mod tests {
             pk_column: Some("fid".to_string()),
             temporal_column: None,
             temporal_end_column: None,
-            other_columns: HashSet::new(),
+            other_columns: HashMap::new(),
         };
         let items = source.items(&filter).await.unwrap();
         assert_eq!(items.features.len(), filter.limit_or_default() as usize);
@@ -636,7 +637,7 @@ mod tests {
             pk_column: Some("fid".to_string()),
             temporal_column: None,
             temporal_end_column: None,
-            other_columns: HashSet::new(),
+            other_columns: HashMap::new(),
         };
         let items = source.items(&filter).await.unwrap();
         assert_eq!(items.features.len(), 10);
@@ -655,7 +656,7 @@ mod tests {
             pk_column: Some("fid".to_string()),
             temporal_column: Some("ts".to_string()),
             temporal_end_column: None,
-            other_columns: HashSet::new(),
+            other_columns: HashMap::new(),
         };
 
         let filter = FilterParams {
@@ -697,6 +698,9 @@ mod tests {
         let ds = PgDatasource::new_pool("postgresql://mvtbench:mvtbench@127.0.0.1:5439/mvtbench")
             .await
             .unwrap();
+
+        let other_columns: HashMap<String, QueryableType> =
+            [("name".to_string(), QueryableType::String)].into();
         let source = PgCollectionSource {
             ds,
             sql: "SELECT *, '2024-01-01 00:00:00Z'::timestamptz - (fid-1) * INTERVAL '1 day' AS ts FROM ne_10m_rivers_lake_centerlines".to_string(),
@@ -704,7 +708,7 @@ mod tests {
             pk_column: Some("fid".to_string()),
             temporal_column: Some("ts".to_string()),
             temporal_end_column: None,
-            other_columns: HashSet::from([("name".to_string())]),
+            other_columns,
         };
 
         let filter = FilterParams {

--- a/bbox-feature-server/src/inventory.rs
+++ b/bbox-feature-server/src/inventory.rs
@@ -200,6 +200,20 @@ impl Inventory {
             }
         }
     }
+
+    pub async fn collection_queryables(&self, collection_id: &str) -> Option<Queryables> {
+        let Some(fc) = self.collection(collection_id) else {
+            warn!("Ignoring error getting collection {collection_id}");
+            return None;
+        };
+        match fc.source.queryables(collection_id).await {
+            Ok(queryables) => queryables,
+            Err(e) => {
+                warn!("Ignoring error getting collection items for {collection_id}: {e}");
+                None
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/bbox-feature-server/src/openapi.yaml
+++ b/bbox-feature-server/src/openapi.yaml
@@ -82,6 +82,17 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+  /collections/{collectionId}/queryables':
+    get:
+      tags:
+        - Queryables
+      summary: the queryable properties of a feature collection in the dataset
+      operationId: getCollectionQueryables
+      responses:
+        '200':
+          $ref: '#/components/responses/Queryables'
+        '500':
+          $ref: '#/components/responses/ServerError'
   '/collections/{collectionId}/items':
     get:
       tags:
@@ -843,6 +854,20 @@ components:
                 rel: license
                 type: application/rdf+xml
                 title: CC0-1.0
+        text/html:
+          schema:
+            type: string
+    Queryables:
+      description: |-
+        Information about the queryable properties for a given feature collection with id `collectionId`.
+
+        The response contains the properties for a given collection which includes:
+
+        * A title and type for the queryable properties;
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/json_schema'
         text/html:
           schema:
             type: string

--- a/bbox-feature-server/templates/queryables.html
+++ b/bbox-feature-server/templates/queryables.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}Queryables{% endblock %}
+{% block content_title %}{{ queryables.title }} Item{% endblock %}
+
+{% block content %}
+<article class="prose">
+<a href="/collections/{{queryables.title}}/queryables.json">JSON</a><br/>
+</article>
+
+<h2>Queryables</h2>
+<ul>
+    {% for prop in queryables.properties %}
+      <li>{{prop}} ({{queryables.properties[prop].type}})</li>
+    {% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
Add a Features API queryables route (json+html)
(https://docs.ogc.org/DRAFTS/19-079r1.html#queryables)

- new function to get column types from the sql query and optionally filter using a list of names
- updated sql building to not require casting to text as the queryable fields types are now known
- updated sql building to use push_bind for the datetime ranges
- updated openapi.yaml