### PR TITLE
Support multiple grids per tileset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Add queryables endpoint to feature server
 * Return layer min-/maxzoom in Tilejson
 * Update to tile-grid 0.6 / ogcapi-types 0.2
-* Add tile SRS override config with opt. zoom level
+* Support multiple grids per tileset with opt. zoom limits
 * Add cache control max-age config with opt. zoom levels
 * CI improvements (PostGIS tests, etc.)
 * Guides and other doc improvements

--- a/bbox-tile-server/src/cli.rs
+++ b/bbox-tile-server/src/cli.rs
@@ -42,6 +42,9 @@ pub struct SeedArgs {
     /// Maximum zoom level
     #[arg(long)]
     pub maxzoom: Option<u8>,
+    /// tile matrix set id
+    #[arg(long)]
+    pub tms: Option<String>,
     /// Extent minx,miny,maxx,maxy (in grid reference system)
     #[arg(long)]
     pub extent: Option<String>,

--- a/bbox-tile-server/src/config.rs
+++ b/bbox-tile-server/src/config.rs
@@ -39,11 +39,9 @@ pub struct TileSetCfg {
     pub name: String,
     // Tile format (Default: Raster)
     // pub format: Option<TileFormatCfg>,
-    /// Tile matrix set identifier (Default: `WebMercatorQuad`)
-    pub tms: Option<String>,
-    /// Spatial reference system of tile data (override grid CRS)
+    /// Tile matrix set identifiers (Default: `["WebMercatorQuad"]`)
     #[serde(default)]
-    pub tile_crs: Vec<TileCrsCfg>,
+    pub tms: Vec<TilesetTmsCfg>,
     /// Tile source
     #[serde(flatten)]
     pub source: SourceParamCfg,
@@ -66,15 +64,17 @@ pub struct GridCfg {
     pub json: String,
 }
 
-/// Spatial reference system of tile data
+/// Available tile grid with optional zoom levels
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
-pub struct TileCrsCfg {
-    /// Spatial reference system of tile data (PostGIS SRID)
-    pub srid: i32,
-    /// Minimum zoom level (Default: 0).
+pub struct TilesetTmsCfg {
+    /// Tile matrix set identifier
+    pub id: String,
+    /// Minimum zoom level for which tiles are available (Default: 0).
     pub minzoom: Option<u8>,
-    /// Maximum zoom level.
+    /// Maximum zoom level for which tiles are available. Defaults to grid maxzoom (24 for `WebMercatorQuad`).
+    ///
+    /// Viewers should use data from tiles at maxzoom when displaying the map at higher zoom levels.
     pub maxzoom: Option<u8>,
 }
 
@@ -130,12 +130,6 @@ pub struct PostgisSourceParamsCfg {
     // maybe we should allow direct DS URLs?
     pub datasource: Option<String>,
     pub extent: Option<ExtentCfg>,
-    /// Minimum zoom level for which tiles are available (Default: 0).
-    pub minzoom: Option<u8>,
-    /// Maximum zoom level for which tiles are available. Defaults to grid maxzoom (24 for `WebMercatorQuad`).
-    ///
-    /// Viewers should use data from tiles at maxzoom when displaying the map at higher zoom levels.
-    pub maxzoom: Option<u8>,
     /// Longitude, latitude of map center (in WGS84).
     ///
     /// Viewers can use this value to set the default location.
@@ -420,8 +414,7 @@ impl ServiceConfig for TileServiceCfg {
                 info!("Adding tileset `{name}`");
                 let ts = TileSetCfg {
                     name,
-                    tms: None,
-                    tile_crs: Vec::new(),
+                    tms: Vec::new(),
                     source: source_cfg,
                     cache: None,
                     cache_format: None,
@@ -472,12 +465,12 @@ impl From<t_rex::ApplicationCfg> for TileServiceCfg {
             Vec::new()
         };
         let tms = if let Some(g) = &t_rex_config.grid.user {
-            Some(format!("{}", g.srid))
+            format!("{}", g.srid)
         } else {
             match &t_rex_config.grid.predefined.as_deref() {
-                Some("wgs84") => Some("WorldCRS84Quad".to_string()),
-                Some("web_mercator") => Some("WebMercatorQuad".to_string()),
-                _ => None,
+                Some("wgs84") => "WorldCRS84Quad".to_string(),
+                Some("web_mercator") => "WebMercatorQuad".to_string(),
+                _ => "WebMercatorQuad".to_string(),
             }
         };
         let tilestore = t_rex_config
@@ -582,8 +575,6 @@ impl From<t_rex::ApplicationCfg> for TileServiceCfg {
                         minx: ext.minx,
                         miny: ext.miny,
                     }),
-                    minzoom: ts.minzoom,
-                    maxzoom: ts.maxzoom,
                     center: ts.center,
                     start_zoom: ts.start_zoom,
                     attribution: ts.attribution,
@@ -593,8 +584,11 @@ impl From<t_rex::ApplicationCfg> for TileServiceCfg {
                 };
                 TileSetCfg {
                     name: ts.name,
-                    tms: tms.clone(),
-                    tile_crs: Vec::new(),
+                    tms: vec![TilesetTmsCfg {
+                        id: tms.clone(),
+                        minzoom: ts.minzoom,
+                        maxzoom: ts.maxzoom,
+                    }],
                     source: SourceParamCfg::Postgis(pgcfg),
                     cache: cache_name.clone(),
                     cache_format: None,
@@ -665,20 +659,16 @@ impl VectorLayerCfg {
         )
     }
     /// Collect min zoom levels
-    pub fn zoom_steps(&self, tile_crs_cfg: &[TileCrsCfg]) -> Vec<u8> {
+    pub fn zoom_steps(&self, tms_cfg: &[TilesetTmsCfg]) -> Vec<u8> {
         let mut zoom_steps: Vec<u8> = self
             .queries
             .iter()
             .filter(|q| q.sql.is_some())
             .filter_map(|q| q.minzoom)
             // Append tile_src minzoom levels
-            .chain(tile_crs_cfg.iter().filter_map(|crs| crs.minzoom))
+            .chain(tms_cfg.iter().filter_map(|crs| crs.minzoom))
             // Append tile_src maxzoom levels
-            .chain(
-                tile_crs_cfg
-                    .iter()
-                    .filter_map(|crs| crs.maxzoom.map(|z| z + 1)),
-            )
+            .chain(tms_cfg.iter().filter_map(|crs| crs.maxzoom.map(|z| z + 1)))
             .filter(|z| *z >= self.minzoom())
             // Append layer minzoom
             .chain([self.minzoom()])
@@ -987,7 +977,6 @@ mod tests {
 
             [[tileset]]
             name = "osm"
-            tms = "WebMercatorQuad"
 
             [tileset.postgis]
             datasource = "osmdb"
@@ -1063,11 +1052,14 @@ mod tests {
 
             [[tileset]]
             name = "tracking"
-            tms = "WebMercatorQuad"
 
-            [[tileset.tile_crs]]
+            [[tileset.tms]]
+            id = "EqualEarthGreenwichWGS84Quad"
             maxzoom = 2
-            srid = 8857
+
+            [[tileset.tms]]
+            id = "WebMercatorQuad"
+            minzoom = 3
 
             [tileset.postgis]
             datasource = "tracking"
@@ -1089,7 +1081,7 @@ mod tests {
         assert_eq!(source.layers[0].minzoom(), 0);
         assert_eq!(source.layers[0].maxzoom(42), 42);
         assert_eq!(source.layers[0].zoom_steps(&[]), vec![0]);
-        assert_eq!(source.layers[0].zoom_steps(&ts.tile_crs), vec![0, 3]);
+        assert_eq!(source.layers[0].zoom_steps(&ts.tms), vec![0, 3]);
     }
 
     #[test]
@@ -1100,11 +1092,14 @@ mod tests {
 
             [[tileset]]
             name = "tracking"
-            tms = "WebMercatorQuad"
 
-            [[tileset.tile_crs]]
+            [[tileset.tms]]
+            id = "EqualEarthGreenwichWGS84Quad"
             maxzoom = 2
-            srid = 8857
+
+            [[tileset.tms]]
+            id = "WebMercatorQuad"
+            minzoom = 3
 
             [tileset.postgis]
             datasource = "osmdb"
@@ -1133,6 +1128,6 @@ mod tests {
         assert_eq!(source.layers[0].minzoom(), 0);
         assert_eq!(source.layers[0].maxzoom(42), 9);
         assert_eq!(source.layers[0].zoom_steps(&[]), vec![0, 3]);
-        assert_eq!(source.layers[0].zoom_steps(&ts.tile_crs), vec![0, 3]);
+        assert_eq!(source.layers[0].zoom_steps(&ts.tms), vec![0, 3]);
     }
 }

--- a/bbox-tile-server/src/config.rs
+++ b/bbox-tile-server/src/config.rs
@@ -1091,7 +1091,7 @@ mod tests {
             json = "EqualEarthGreenwichWGS84Quad.json"
 
             [[tileset]]
-            name = "tracking"
+            name = "ocean"
 
             [[tileset.tms]]
             id = "EqualEarthGreenwichWGS84Quad"

--- a/bbox-tile-server/src/config.rs
+++ b/bbox-tile-server/src/config.rs
@@ -969,7 +969,7 @@ mod tests {
 
     #[test]
     fn zoom_steps() {
-        const CONFIG: &'static str = r#"
+        const CONFIG: &str = r#"
             [[datasource]]
             name = "osmdb"
             [datasource.postgis]
@@ -1013,7 +1013,7 @@ mod tests {
 
     #[test]
     fn zoom_min_max() {
-        const CONFIG: &'static str = r#"
+        const CONFIG: &str = r#"
             [[tileset]]
             name = "osm"
 
@@ -1046,7 +1046,7 @@ mod tests {
 
     #[test]
     fn multi_crs_projected() {
-        const CONFIG: &'static str = r#"
+        const CONFIG: &str = r#"
             [[grid]]
             json = "EqualEarthGreenwichWGS84Quad.json"
 
@@ -1086,7 +1086,7 @@ mod tests {
 
     #[test]
     fn multi_crs_unprojected() {
-        const CONFIG: &'static str = r#"
+        const CONFIG: &str = r#"
             [[grid]]
             json = "EqualEarthGreenwichWGS84Quad.json"
 

--- a/bbox-tile-server/src/datasource/mbtiles.rs
+++ b/bbox-tile-server/src/datasource/mbtiles.rs
@@ -5,21 +5,19 @@ use crate::datasource::{
     wms_fcgi::HttpRequestParams, LayerInfo, SourceType, TileRead, TileResponse, TileSourceError,
 };
 use crate::filter_params::FilterParams;
-use crate::service::TileService;
 use crate::store::mbtiles::MbtilesStore;
 use crate::store::TileReader;
 use async_trait::async_trait;
 use bbox_core::Format;
 use martin_mbtiles::Metadata;
-use tile_grid::Xyz;
+use tile_grid::{Tms, Xyz};
 use tilejson::TileJSON;
 
 #[async_trait]
 impl TileRead for MbtilesStore {
     async fn xyz_request(
         &self,
-        _service: &TileService,
-        _tms_id: &str,
+        _tms: &Tms,
         tile: &Xyz,
         _filter: &FilterParams,
         _format: &Format,

--- a/bbox-tile-server/src/datasource/mbtiles.rs
+++ b/bbox-tile-server/src/datasource/mbtiles.rs
@@ -36,7 +36,7 @@ impl TileRead for MbtilesStore {
     fn source_type(&self) -> SourceType {
         SourceType::Vector // TODO: Support Mbtiles raster
     }
-    async fn tilejson(&self, _format: &Format) -> Result<TileJSON, TileSourceError> {
+    async fn tilejson(&self, _tms: &Tms, _format: &Format) -> Result<TileJSON, TileSourceError> {
         let metadata = self.mbt.get_metadata().await?;
         Ok(metadata.tilejson)
     }

--- a/bbox-tile-server/src/datasource/mbtiles.rs
+++ b/bbox-tile-server/src/datasource/mbtiles.rs
@@ -2,7 +2,7 @@
 
 use crate::config::TileSetCfg;
 use crate::datasource::{
-    wms_fcgi::HttpRequestParams, LayerInfo, SourceType, TileRead, TileResponse, TileSourceError,
+    wms_fcgi::HttpRequestParams, LayerInfo, SourceType, TileResponse, TileSource, TileSourceError,
 };
 use crate::filter_params::FilterParams;
 use crate::store::mbtiles::MbtilesStore;
@@ -14,7 +14,7 @@ use tile_grid::{Tms, Xyz};
 use tilejson::TileJSON;
 
 #[async_trait]
-impl TileRead for MbtilesStore {
+impl TileSource for MbtilesStore {
     async fn xyz_request(
         &self,
         _tms: &Tms,

--- a/bbox-tile-server/src/datasource/mod.rs
+++ b/bbox-tile-server/src/datasource/mod.rs
@@ -191,7 +191,7 @@ impl Datasources {
                         "wms_proxy".to_string(),
                     ))
                 };
-                let first_srid = ts_grids.first().expect("default grid missing").tms.srid();
+                let first_srid = ts_grids.first().expect("default grid missing").tms.srid(); // TODO: Support multiple grids
                 Box::new(wms_http::WmsHttpSource::from_config(
                     provider, cfg, first_srid,
                 ))

--- a/bbox-tile-server/src/datasource/mod.rs
+++ b/bbox-tile-server/src/datasource/mod.rs
@@ -73,7 +73,7 @@ pub struct LayerInfo {
 }
 
 #[async_trait]
-pub trait TileRead: DynClone + Send + Sync {
+pub trait TileSource: DynClone + Send + Sync {
     /// Request tile from source
     async fn xyz_request(
         &self,
@@ -125,7 +125,7 @@ pub trait TileRead: DynClone + Send + Sync {
     }
 }
 
-clone_trait_object!(TileRead);
+clone_trait_object!(TileSource);
 
 /// Datasource connection pools
 #[derive(Default)]
@@ -163,7 +163,7 @@ impl Datasources {
         cfg: &SourceParamCfg,
         ts_grids: &[TileSetGrid],
         tms_cfg: &[TilesetTmsCfg],
-    ) -> Box<dyn TileRead> {
+    ) -> Box<dyn TileSource> {
         // -- raster sources --
         // wms_fcgi::WmsFcgiSource,
         // wms_http::WmsHttpSource,

--- a/bbox-tile-server/src/datasource/pmtiles.rs
+++ b/bbox-tile-server/src/datasource/pmtiles.rs
@@ -36,7 +36,7 @@ impl TileRead for PmtilesStoreReader {
     fn source_type(&self) -> SourceType {
         SourceType::Vector //TODO
     }
-    async fn tilejson(&self, format: &Format) -> Result<TileJSON, TileSourceError> {
+    async fn tilejson(&self, _tms: &Tms, format: &Format) -> Result<TileJSON, TileSourceError> {
         debug!(
             "Metadata {}: {}",
             self.path.display(),

--- a/bbox-tile-server/src/datasource/pmtiles.rs
+++ b/bbox-tile-server/src/datasource/pmtiles.rs
@@ -1,7 +1,7 @@
 //! PMTiles tile source.
 
 use crate::datasource::{
-    wms_fcgi::HttpRequestParams, LayerInfo, SourceType, TileRead, TileResponse, TileSourceError,
+    wms_fcgi::HttpRequestParams, LayerInfo, SourceType, TileResponse, TileSource, TileSourceError,
 };
 use crate::filter_params::FilterParams;
 use crate::store::pmtiles::PmtilesStoreReader;
@@ -14,7 +14,7 @@ use tilejson::tilejson;
 use tilejson::TileJSON;
 
 #[async_trait]
-impl TileRead for PmtilesStoreReader {
+impl TileSource for PmtilesStoreReader {
     async fn xyz_request(
         &self,
         _tms: &Tms,

--- a/bbox-tile-server/src/datasource/pmtiles.rs
+++ b/bbox-tile-server/src/datasource/pmtiles.rs
@@ -4,13 +4,12 @@ use crate::datasource::{
     wms_fcgi::HttpRequestParams, LayerInfo, SourceType, TileRead, TileResponse, TileSourceError,
 };
 use crate::filter_params::FilterParams;
-use crate::service::TileService;
 use crate::store::pmtiles::PmtilesStoreReader;
 use crate::store::TileReader;
 use async_trait::async_trait;
 use bbox_core::Format;
 use log::debug;
-use tile_grid::Xyz;
+use tile_grid::{Tms, Xyz};
 use tilejson::tilejson;
 use tilejson::TileJSON;
 
@@ -18,8 +17,7 @@ use tilejson::TileJSON;
 impl TileRead for PmtilesStoreReader {
     async fn xyz_request(
         &self,
-        _service: &TileService,
-        _tms_id: &str,
+        _tms: &Tms,
         tile: &Xyz,
         _filter: &FilterParams,
         _format: &Format,

--- a/bbox-tile-server/src/datasource/postgis.rs
+++ b/bbox-tile-server/src/datasource/postgis.rs
@@ -123,11 +123,11 @@ impl PgSource {
         }
 
         fn tile_srid_z(ts_grids: &[TileSetGrid], zoom: u8) -> Option<i32> {
-            let entry = ts_grids
+            ts_grids
                 .iter()
                 .rev()
-                .find(|entry| entry.minzoom <= zoom && entry.maxzoom >= zoom);
-            entry.map(|e| e.tms.srid())
+                .find(|entry| entry.minzoom <= zoom && entry.maxzoom >= zoom)
+                .map(|entry| entry.tms.srid())
         }
 
         let zoom_steps = layer.zoom_steps(tms_cfg);

--- a/bbox-tile-server/src/datasource/postgis.rs
+++ b/bbox-tile-server/src/datasource/postgis.rs
@@ -5,7 +5,7 @@ use crate::datasource::{
     mvt::MvtBuilder,
     postgis_queries::{QueryParam, SqlQuery},
     wms_fcgi::HttpRequestParams,
-    LayerInfo, SourceType, TileRead, TileSourceError,
+    LayerInfo, SourceType, TileSource, TileSourceError,
 };
 use crate::filter_params::FilterParams;
 use crate::service::{TileSetGrid, TmsExtensions};
@@ -308,7 +308,7 @@ fn layer_query<'a>(
 }
 
 #[async_trait]
-impl TileRead for PgSource {
+impl TileSource for PgSource {
     async fn xyz_request(
         &self,
         tms: &Tms,

--- a/bbox-tile-server/src/datasource/postgis.rs
+++ b/bbox-tile-server/src/datasource/postgis.rs
@@ -393,16 +393,16 @@ impl TileRead for PgSource {
     fn source_type(&self) -> SourceType {
         SourceType::Vector
     }
-    async fn tilejson(&self, format: &Format) -> Result<TileJSON, TileSourceError> {
+    async fn tilejson(&self, tms: &Tms, format: &Format) -> Result<TileJSON, TileSourceError> {
         let mut tj = tilejson! { tiles: vec![] };
         tj.attribution = Some(self.config.attribution());
         // Minimum zoom level for which tiles are available.
         // Optional. Default: 0. >= 0, <= 30.
-        // tj.minzoom = Some(self.config.minzoom.unwrap_or(0)); TODO: from grid
+        tj.minzoom = Some(tms.minzoom());
         // Maximum zoom level for which tiles are available.
         // Data from tiles at the maxzoom are used when displaying the map at higher zoom levels.
         // Optional. Default: 30. >= 0, <= 30. (Mapbox Style default: 22)
-        // tj.maxzoom = Some(self.maxzoom); TODO: from grid
+        tj.maxzoom = Some(tms.maxzoom());
         let extent = self.config.get_extent();
         tj.bounds = Some(tilejson::Bounds {
             left: extent.minx,

--- a/bbox-tile-server/src/datasource/postgis.rs
+++ b/bbox-tile-server/src/datasource/postgis.rs
@@ -1,6 +1,6 @@
 //! PostGIS tile source.
 
-use crate::config::{PostgisSourceParamsCfg, TileCrsCfg, VectorLayerCfg};
+use crate::config::{PostgisSourceParamsCfg, TilesetTmsCfg, VectorLayerCfg};
 use crate::datasource::{
     mvt::MvtBuilder,
     postgis_queries::{QueryParam, SqlQuery},
@@ -8,7 +8,7 @@ use crate::datasource::{
     LayerInfo, SourceType, TileRead, TileSourceError,
 };
 use crate::filter_params::FilterParams;
-use crate::service::TileService;
+use crate::service::{TileSetGrid, TmsExtensions};
 use async_trait::async_trait;
 use bbox_core::pg_ds::PgDatasource;
 use bbox_core::{Format, TileResponse};
@@ -28,8 +28,6 @@ use tilejson::{tilejson, TileJSON};
 #[derive(Clone, Debug)]
 pub struct PgSource {
     ds: PgDatasource,
-    grid_srid: i32,
-    maxzoom: u8,
     layers: BTreeMap<String, PgMvtLayer>,
     /// Config with TileJSON metadata
     config: PostgisSourceParamsCfg,
@@ -43,8 +41,8 @@ pub struct PgMvtLayer {
     tile_size: u32,
     fid_field: Option<String>,
     query_limit: Option<u32>,
-    /// Queries for zoom steps
-    queries: HashMap<u8, QueryInfo>,
+    /// Queries for zoom steps for each grid_srid
+    queries: HashMap<i32, HashMap<u8, QueryInfo>>,
     /// Query zoom step for all zoom levels (z -> minzoom step)
     query_zoom_steps: HashMap<u8, u8>,
 }
@@ -74,10 +72,10 @@ pub type Datasource = PgDatasource;
 
 impl PgMvtLayer {
     /// Get query for zoom level
-    fn query(&self, zoom: u8) -> Option<&QueryInfo> {
+    fn query(&self, grid_srid: i32, zoom: u8) -> Option<&QueryInfo> {
         self.query_zoom_steps
             .get(&zoom)
-            .and_then(|minzoom| self.queries.get(minzoom))
+            .and_then(|minzoom| self.queries.get(&grid_srid).and_then(|gq| gq.get(minzoom)))
     }
     pub fn minzoom(&self) -> u8 {
         *self.query_zoom_steps.keys().min().unwrap_or(&0)
@@ -91,16 +89,12 @@ impl PgSource {
     pub async fn create(
         ds: &PgDatasource,
         cfg: &PostgisSourceParamsCfg,
-        tms: &Tms,
-        tile_crs_cfg: &[TileCrsCfg],
+        ts_grids: &[TileSetGrid],
+        tms_cfg: &[TilesetTmsCfg],
     ) -> PgSource {
-        let grid_srid = tms.crs().as_srid();
-        let maxzoom = cfg.maxzoom.unwrap_or(tms.maxzoom());
-
         let mut layers = BTreeMap::new();
         for layer in &cfg.layers {
-            match Self::setup_layer(ds, layer, grid_srid, tile_crs_cfg, maxzoom, cfg.postgis2).await
-            {
+            match Self::setup_layer(ds, layer, ts_grids, tms_cfg, cfg.postgis2).await {
                 Ok(mvt_layer) => {
                     layers.insert(layer.name.clone(), mvt_layer);
                 }
@@ -111,8 +105,6 @@ impl PgSource {
         }
         PgSource {
             ds: ds.clone(),
-            grid_srid,
-            maxzoom,
             layers,
             config: cfg.clone(),
         }
@@ -120,9 +112,8 @@ impl PgSource {
     async fn setup_layer(
         ds: &PgDatasource,
         layer: &VectorLayerCfg,
-        grid_srid: i32,
-        tile_crs_cfg: &[TileCrsCfg],
-        maxzoom: u8,
+        ts_grids: &[TileSetGrid],
+        tms_cfg: &[TilesetTmsCfg],
         postgis2: bool,
     ) -> Result<PgMvtLayer, TileSourceError> {
         // Configuration checks (TODO: add config_check to trait)
@@ -131,106 +122,118 @@ impl PgSource {
             return Err(TileSourceError::TypeDetectionError);
         }
 
-        fn tile_srid_z(tile_crs_cfg: &[TileCrsCfg], zoom: u8) -> Option<i32> {
-            let entry = tile_crs_cfg.iter().rev().find(|entry| {
-                entry.minzoom.unwrap_or(0) <= zoom && entry.maxzoom.unwrap_or(255) >= zoom
-            });
-            entry.map(|e| e.srid)
+        fn tile_srid_z(ts_grids: &[TileSetGrid], zoom: u8) -> Option<i32> {
+            let entry = ts_grids
+                .iter()
+                .rev()
+                .find(|entry| entry.minzoom <= zoom && entry.maxzoom >= zoom);
+            entry.map(|e| e.tms.srid())
         }
 
-        let mut layer_queries = HashMap::new();
-        let zoom_steps = layer.zoom_steps(tile_crs_cfg);
+        let zoom_steps = layer.zoom_steps(tms_cfg);
         if zoom_steps.len() > 1 {
             debug!("Layer `{}` zoom steps: {:?}", layer.name, zoom_steps);
         }
-        for zoom in zoom_steps {
-            let layer_query = layer.query(zoom);
-            let tile_srid = tile_srid_z(tile_crs_cfg, zoom).unwrap_or(grid_srid);
-            let field_query = SqlQuery::build_field_query(layer, layer_query);
-            let param_types = field_query.param_types();
-            let mut geometry_field = None;
-            let mut fields = Vec::new();
-            match ds.pool.prepare_with(&field_query.sql, &param_types).await {
-                Ok(stmt) => {
-                    for col in stmt.columns() {
-                        let info = column_info(col, &layer.name);
-                        if let Some(geom_col) = &layer.geometry_field {
-                            if col.name() == geom_col {
-                                if info == FieldTypeInfo::Geometry {
-                                    geometry_field = Some(geom_col.to_string());
-                                } else {
-                                    error!(
-                                        "Layer `{}` z{zoom}: Unsupported geometry type",
-                                        layer.name
-                                    );
-                                    continue;
+        let mut layer_queries = HashMap::new();
+        for grid in ts_grids {
+            for zs in &zoom_steps {
+                let zoom = *zs;
+                let layer_query = layer.query(zoom);
+                let tile_srid = tile_srid_z(ts_grids, zoom).unwrap_or(grid.tms.srid());
+                let field_query = SqlQuery::build_field_query(layer, layer_query);
+                let param_types = field_query.param_types();
+                let mut geometry_field = None;
+                let mut fields = Vec::new();
+                match ds.pool.prepare_with(&field_query.sql, &param_types).await {
+                    Ok(stmt) => {
+                        for col in stmt.columns() {
+                            let info = column_info(col, &layer.name);
+                            if let Some(geom_col) = &layer.geometry_field {
+                                if col.name() == geom_col {
+                                    if info == FieldTypeInfo::Geometry {
+                                        geometry_field = Some(geom_col.to_string());
+                                    } else {
+                                        error!(
+                                            "Layer `{}` z{zoom}: Unsupported geometry type",
+                                            layer.name
+                                        );
+                                        continue;
+                                    }
                                 }
+                            } else if info == FieldTypeInfo::Geometry && geometry_field.is_none() {
+                                // Default: use first geometry column
+                                geometry_field = Some(col.name().to_string());
                             }
-                        } else if info == FieldTypeInfo::Geometry && geometry_field.is_none() {
-                            // Default: use first geometry column
-                            geometry_field = Some(col.name().to_string());
+                            if info != FieldTypeInfo::Ignored {
+                                let field_info = FieldInfo {
+                                    name: col.name().to_string(),
+                                    info,
+                                };
+                                fields.push(field_info);
+                            }
                         }
-                        if info != FieldTypeInfo::Ignored {
-                            let field_info = FieldInfo {
-                                name: col.name().to_string(),
-                                info,
-                            };
-                            fields.push(field_info);
-                        }
+                        debug!("Query parameters: {:?}", stmt.parameters());
                     }
-                    debug!("Query parameters: {:?}", stmt.parameters());
-                }
-                Err(e) => {
-                    error!(
-                        "Layer `{}` z{zoom}: Field detection failed - {e}",
-                        layer.name
-                    );
-                    error!(" Query: {}", field_query.sql);
+                    Err(e) => {
+                        error!(
+                            "Layer `{}` z{zoom}: Field detection failed - {e}",
+                            layer.name
+                        );
+                        error!(" Query: {}", field_query.sql);
+                        return Err(TileSourceError::TypeDetectionError);
+                    }
+                };
+                let Some(geometry_field) = geometry_field else {
+                    error!("Layer `{}`: No geometry column found", layer.name);
                     return Err(TileSourceError::TypeDetectionError);
-                }
-            };
-            let Some(geometry_field) = geometry_field else {
-                error!("Layer `{}`: No geometry column found", layer.name);
-                return Err(TileSourceError::TypeDetectionError);
-            };
-            let geom_name = layer.geometry_field.as_ref().unwrap_or(&geometry_field);
-            let query = SqlQuery::build_tile_query(
-                layer,
-                geom_name,
-                &fields,
-                tile_srid,
-                zoom,
-                layer_query,
-                postgis2,
-            );
-            let param_types = query.param_types();
-            let stmt = match ds.pool.prepare_with(&query.sql, &param_types).await {
-                Ok(stmt) => Statement::to_owned(&stmt), //stmt.to_owned()
-                Err(e) => {
-                    error!("Layer `{}` z{zoom}: Invalid query - {e}", layer.name);
-                    error!(" Query: {}", query.sql);
-                    return Err(TileSourceError::TypeDetectionError);
-                }
-            };
-            // Workaround for cached queries with incorrect parameter types
-            // for _ in 0..ds.pool.size() {
-            //     ds.pool.acquire().await?.clear_cached_statements().await?;
-            // }
-            debug!(
-                "Layer `{}`: Query for minzoom {zoom}: {}",
-                layer.name, query.sql
-            );
-            let query_info = QueryInfo {
-                stmt,
-                params: query.params.clone(),
-                fields: fields.clone(),
-                geometry_field: geometry_field.clone(),
-            };
-            layer_queries.insert(zoom, query_info);
+                };
+                let geom_name = layer.geometry_field.as_ref().unwrap_or(&geometry_field);
+                let query = SqlQuery::build_tile_query(
+                    layer,
+                    geom_name,
+                    &fields,
+                    tile_srid,
+                    zoom,
+                    layer_query,
+                    postgis2,
+                );
+                let param_types = query.param_types();
+                let stmt = match ds.pool.prepare_with(&query.sql, &param_types).await {
+                    Ok(stmt) => Statement::to_owned(&stmt), //stmt.to_owned()
+                    Err(e) => {
+                        error!("Layer `{}` z{zoom}: Invalid query - {e}", layer.name);
+                        error!(" Query: {}", query.sql);
+                        return Err(TileSourceError::TypeDetectionError);
+                    }
+                };
+                // Workaround for cached queries with incorrect parameter types
+                // for _ in 0..ds.pool.size() {
+                //     ds.pool.acquire().await?.clear_cached_statements().await?;
+                // }
+                debug!(
+                    "Layer `{}`: Query for minzoom {zoom}: {}",
+                    layer.name, query.sql
+                );
+                let query_info = QueryInfo {
+                    stmt,
+                    params: query.params.clone(),
+                    fields: fields.clone(),
+                    geometry_field: geometry_field.clone(),
+                };
+                layer_queries
+                    .entry(tile_srid)
+                    .or_insert(HashMap::new())
+                    .insert(zoom, query_info);
+            }
         }
 
         // Lookup table for all zoom levels
-        let zoom_steps = layer.zoom_steps(tile_crs_cfg);
+        let zoom_steps = layer.zoom_steps(tms_cfg);
+        let maxzoom = ts_grids
+            .iter()
+            .map(|g| g.tms.maxzoom())
+            .max()
+            .expect("default grid missing");
         let mut query_zoom_steps = HashMap::new();
         for zoom in layer.minzoom()..=layer.maxzoom(maxzoom) {
             let z = zoom_steps
@@ -308,26 +311,25 @@ fn layer_query<'a>(
 impl TileRead for PgSource {
     async fn xyz_request(
         &self,
-        service: &TileService,
-        tms_id: &str,
+        tms: &Tms,
         tile: &Xyz,
         filter: &FilterParams,
         _format: &Format,
         _request_params: HttpRequestParams<'_>,
     ) -> Result<TileResponse, TileSourceError> {
-        let grid = service.grid(tms_id)?;
-        let extent_info = service.xyz_extent(tms_id, tile)?;
+        let extent_info = tms.xyz_extent(tile)?;
         let extent = &extent_info.extent;
         debug!(
             "Query tile {}/{}/{} with {extent:?}",
             tile.z, tile.x, tile.y
         );
+        let tile_srid = tms.srid();
         let mut mvt = MvtBuilder::new();
         for (id, layer) in &self.layers {
-            let Some(query_info) = layer.query(tile.z) else {
+            let Some(query_info) = layer.query(tile_srid, tile.z) else {
                 continue;
             };
-            let query = layer_query(layer, query_info, tile, grid, extent, filter)?;
+            let query = layer_query(layer, query_info, tile, tms, extent, filter)?;
             debug!("Query layer `{id}`");
             let mut rows = query.fetch(&self.ds.pool);
             let mut mvt_layer = MvtBuilder::new_layer(id, layer.tile_size);
@@ -396,11 +398,11 @@ impl TileRead for PgSource {
         tj.attribution = Some(self.config.attribution());
         // Minimum zoom level for which tiles are available.
         // Optional. Default: 0. >= 0, <= 30.
-        tj.minzoom = Some(self.config.minzoom.unwrap_or(0));
+        // tj.minzoom = Some(self.config.minzoom.unwrap_or(0)); TODO: from grid
         // Maximum zoom level for which tiles are available.
         // Data from tiles at the maxzoom are used when displaying the map at higher zoom levels.
         // Optional. Default: 30. >= 0, <= 30. (Mapbox Style default: 22)
-        tj.maxzoom = Some(self.maxzoom);
+        // tj.maxzoom = Some(self.maxzoom); TODO: from grid
         let extent = self.config.get_extent();
         tj.bounds = Some(tilejson::Bounds {
             left: extent.minx,
@@ -416,11 +418,12 @@ impl TileRead for PgSource {
         });
         tj.other
             .insert("format".to_string(), format.file_suffix().into());
-        if self.grid_srid != 3857 {
+        let grid_srid = 3857; // TODO: from tileset
+        if grid_srid != 3857 {
             // TODO: add full grid information according to GDAL extension
             // https://github.com/OSGeo/gdal/blob/release/3.4/gdal/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp#L5497
             tj.other
-                .insert("srs".to_string(), format!("EPSG:{}", self.grid_srid).into());
+                .insert("srs".to_string(), format!("EPSG:{}", grid_srid).into());
         }
         // TODO: advertise zoom level specific srids
         let mut layers: Vec<tilejson::VectorLayer> = self
@@ -430,6 +433,8 @@ impl TileRead for PgSource {
                 // Collected fields from all zoom step levels
                 let fields = layer
                     .queries
+                    .get(&grid_srid)
+                    .unwrap()
                     .clone()
                     .into_values()
                     .flat_map(|q| q.fields)
@@ -665,8 +670,6 @@ mod tests {
         let pg_src_cfg = PostgisSourceParamsCfg {
             datasource: None,
             extent: None,
-            minzoom: None,
-            maxzoom: None,
             center: None,
             start_zoom: None,
             attribution: None,
@@ -674,9 +677,14 @@ mod tests {
             diagnostics: None,
             layers: vec![layer],
         };
-        let ds = PgDatasource::from_config(&ds_cfg, None).await.unwrap();
         let tms = tms().lookup("WebMercatorQuad").unwrap();
-        PgSource::create(&ds, &pg_src_cfg, &tms, &Vec::new()).await
+        let ts_grids = vec![TileSetGrid {
+            tms,
+            minzoom: 0,
+            maxzoom: 24,
+        }];
+        let ds = PgDatasource::from_config(&ds_cfg, None).await.unwrap();
+        PgSource::create(&ds, &pg_src_cfg, &ts_grids, &Vec::new()).await
     }
 
     #[test(tokio::test)]
@@ -686,7 +694,7 @@ mod tests {
         let layer = pg.layers.get("layer1").unwrap();
         let tms = tms().lookup("WebMercatorQuad").unwrap();
         let tile = Xyz::new(0, 0, 0);
-        let query_info = layer.query(tile.z).unwrap();
+        let query_info = layer.query(tms.srid(), tile.z).unwrap();
         let extent = tms.xy_bounds(&tile);
         let filter = FilterParams::default();
         let query = layer_query(layer, query_info, &tile, &tms, &extent, &filter).unwrap();
@@ -707,7 +715,7 @@ mod tests {
         let layer = pg.layers.get("layer1").unwrap();
         let tms = tms().lookup("WebMercatorQuad").unwrap();
         let tile = Xyz::new(0, 0, 0);
-        let query_info = layer.query(tile.z).unwrap();
+        let query_info = layer.query(tms.srid(), tile.z).unwrap();
         let extent = tms.xy_bounds(&tile);
         let filter = FilterParams::default();
         let query = layer_query(layer, query_info, &tile, &tms, &extent, &filter).unwrap();

--- a/bbox-tile-server/src/datasource/postgis_queries.rs
+++ b/bbox-tile-server/src/datasource/postgis_queries.rs
@@ -92,7 +92,6 @@ impl SqlQuery {
     /// Replace variables (!bbox!, !zoom!, etc.) in query
     // https://github.com/mapnik/mapnik/wiki/PostGIS
     fn replace_params(sqlin: &str, bbox_expr: String, bbox_expr_unbuffered: String) -> Self {
-        let re = Regex::new(r"!(\w+)!").expect("regex");
         let mut sql = sqlin.to_string();
         let mut params = Vec::new();
         let mut numvars = 0;
@@ -127,6 +126,7 @@ impl SqlQuery {
         }
         // Search and replace field query vars
         let mut unique_fields = BTreeSet::new();
+        let re = Regex::new(r"!(\w+)!").expect("regex");
         for (_, [field]) in re.captures_iter(&sql).map(|c| c.extract()) {
             unique_fields.insert(field.to_string());
         }

--- a/bbox-tile-server/src/datasource/wms_fcgi.rs
+++ b/bbox-tile-server/src/datasource/wms_fcgi.rs
@@ -119,7 +119,7 @@ impl TileRead for WmsFcgiSource {
             DUMMY_METRICS.get_or_init(WmsMetrics::default)
         }
     }
-    async fn tilejson(&self, format: &Format) -> Result<TileJSON, TileSourceError> {
+    async fn tilejson(&self, _tms: &Tms, format: &Format) -> Result<TileJSON, TileSourceError> {
         let mut tj = tilejson! { tiles: vec![] };
         tj.other
             .insert("format".to_string(), format.file_suffix().into());

--- a/bbox-tile-server/src/datasource/wms_fcgi.rs
+++ b/bbox-tile-server/src/datasource/wms_fcgi.rs
@@ -1,7 +1,7 @@
 //! FCGI tile sources like QGIS Server or UMN Mapsever.
 
 use crate::config::WmsFcgiSourceParamsCfg;
-use crate::datasource::{LayerInfo, SourceType, TileRead, TileSourceError};
+use crate::datasource::{LayerInfo, SourceType, TileSource, TileSourceError};
 use crate::filter_params::FilterParams;
 use crate::service::{QueryExtent, TmsExtensions};
 use async_trait::async_trait;
@@ -92,7 +92,7 @@ impl WmsFcgiSource {
 }
 
 #[async_trait]
-impl TileRead for WmsFcgiSource {
+impl TileSource for WmsFcgiSource {
     async fn xyz_request(
         &self,
         tms: &Tms,

--- a/bbox-tile-server/src/datasource/wms_http.rs
+++ b/bbox-tile-server/src/datasource/wms_http.rs
@@ -5,13 +5,13 @@ use crate::datasource::{
     wms_fcgi::HttpRequestParams, LayerInfo, SourceType, TileRead, TileSourceError,
 };
 use crate::filter_params::FilterParams;
-use crate::service::TileService;
+use crate::service::TmsExtensions;
 use async_trait::async_trait;
 use bbox_core::config::WmsHttpSourceProviderCfg;
 use bbox_core::{Format, TileResponse};
 use log::debug;
 use std::io::Cursor;
-use tile_grid::{BoundingBox, Xyz};
+use tile_grid::{BoundingBox, Tms, Xyz};
 use tilejson::{tilejson, TileJSON};
 
 #[derive(Clone, Debug)]
@@ -73,14 +73,13 @@ impl WmsHttpSource {
 impl TileRead for WmsHttpSource {
     async fn xyz_request(
         &self,
-        service: &TileService,
-        tms_id: &str,
+        tms: &Tms,
         tile: &Xyz,
         _filter: &FilterParams,
         _format: &Format,
         _request_params: HttpRequestParams<'_>,
     ) -> Result<TileResponse, TileSourceError> {
-        let extent_info = service.xyz_extent(tms_id, tile)?;
+        let extent_info = tms.xyz_extent(tile)?;
         self.bbox_request(&extent_info.extent).await
     }
     fn source_type(&self) -> SourceType {

--- a/bbox-tile-server/src/datasource/wms_http.rs
+++ b/bbox-tile-server/src/datasource/wms_http.rs
@@ -2,7 +2,7 @@
 
 use crate::config::WmsHttpSourceParamsCfg;
 use crate::datasource::{
-    wms_fcgi::HttpRequestParams, LayerInfo, SourceType, TileRead, TileSourceError,
+    wms_fcgi::HttpRequestParams, LayerInfo, SourceType, TileSource, TileSourceError,
 };
 use crate::filter_params::FilterParams;
 use crate::service::TmsExtensions;
@@ -70,7 +70,7 @@ impl WmsHttpSource {
 }
 
 #[async_trait]
-impl TileRead for WmsHttpSource {
+impl TileSource for WmsHttpSource {
     async fn xyz_request(
         &self,
         tms: &Tms,

--- a/bbox-tile-server/src/datasource/wms_http.rs
+++ b/bbox-tile-server/src/datasource/wms_http.rs
@@ -85,7 +85,7 @@ impl TileRead for WmsHttpSource {
     fn source_type(&self) -> SourceType {
         SourceType::Raster
     }
-    async fn tilejson(&self, format: &Format) -> Result<TileJSON, TileSourceError> {
+    async fn tilejson(&self, _tms: &Tms, format: &Format) -> Result<TileJSON, TileSourceError> {
         let mut tj = tilejson! { tiles: vec![] };
         tj.other
             .insert("format".to_string(), format.file_suffix().into());

--- a/bbox-tile-server/src/endpoints.rs
+++ b/bbox-tile-server/src/endpoints.rs
@@ -41,7 +41,8 @@ async fn tilejson(
         .tileset(&tileset)
         .ok_or(ServiceError::TilesetNotFound(tileset.clone()))
         .unwrap();
-    if let Ok(tilejson) = ts.tilejson(&absurl).await {
+    let tms = ts.default_grid(0).expect("default grid missing");
+    if let Ok(tilejson) = ts.tilejson(tms, &absurl).await {
         HttpResponse::Ok().json(tilejson)
     } else {
         HttpResponse::InternalServerError().finish()

--- a/bbox-tile-server/src/endpoints.rs
+++ b/bbox-tile-server/src/endpoints.rs
@@ -162,10 +162,7 @@ async fn tile_request(
         req_path: req.path(),
         metrics: &metrics,
     };
-    let tms = tms.unwrap_or(
-        ts.default_grid(z)
-            .expect("default grid missing or z out of range"),
-    );
+    let tms = tms.unwrap_or(ts.default_grid(z)?);
     match ts
         .tile_cached(tms, &tile, &fp, format, compression, request_params)
         .await

--- a/bbox-tile-server/src/seed.rs
+++ b/bbox-tile-server/src/seed.rs
@@ -62,9 +62,9 @@ impl TileService {
         let tileset_arc = Arc::new(tileset.clone());
         let tms = Arc::new(
             if let Some(tms_id) = &args.tms {
-                tileset.grid(&tms_id)?
+                tileset.grid(tms_id)?
             } else {
-                tileset.default_grid(0).expect("default grid missing")
+                tileset.default_grid(0)?
             }
             .clone(),
         );

--- a/bbox-tile-server/src/seed.rs
+++ b/bbox-tile-server/src/seed.rs
@@ -61,10 +61,12 @@ impl TileService {
             .clone();
         let tileset_arc = Arc::new(tileset.clone());
         let tms = Arc::new(
-            tileset
-                .default_grid(0)
-                .expect("default grid missing") //FIXME: grid from args and/or zoom dependencies
-                .clone(),
+            if let Some(tms_id) = &args.tms {
+                tileset.grid(&tms_id)?
+            } else {
+                tileset.default_grid(0).expect("default grid missing")
+            }
+            .clone(),
         );
         let format = *tileset.tile_format();
 
@@ -114,8 +116,8 @@ impl TileService {
         });
         let par_stream = stream::iter(iter).par_then(threads, move |xyz| {
             let tileset = tileset_arc.clone();
+            let tms = tms.clone(); // TODO: tileset.default_grid(xyz.z)
             let filter = FilterParams::default();
-            let tms = tms.clone();
             let compression = compression.clone();
             async move {
                 let tile = tileset

--- a/bbox-tile-server/src/service.rs
+++ b/bbox-tile-server/src/service.rs
@@ -1,7 +1,7 @@
 use crate::cli::Commands;
 use crate::config::*;
 use crate::datasource::wms_fcgi::{HttpRequestParams, MapService};
-use crate::datasource::{Datasources, SourceType, TileRead, TileSourceError};
+use crate::datasource::{Datasources, SourceType, TileSource, TileSourceError};
 use crate::filter_params::FilterParams;
 use crate::store::{
     store_reader_from_config, store_writer_from_config, TileReader, TileStoreError, TileWriter,
@@ -35,7 +35,7 @@ pub struct TileSet {
     pub name: String,
     /// Tile matrix sets
     pub tms: Vec<TileSetGrid>,
-    pub source: Box<dyn TileRead>,
+    pub source: Box<dyn TileSource>,
     format: Format,
     pub store_reader: Option<Box<dyn TileReader>>,
     pub store_writer: Option<Box<dyn TileWriter>>,
@@ -75,11 +75,11 @@ pub enum ServiceError {
 impl actix_web::error::ResponseError for ServiceError {}
 
 pub trait SourceLookup {
-    fn source(&self, tileset: &str) -> Option<&dyn TileRead>;
+    fn source(&self, tileset: &str) -> Option<&dyn TileSource>;
 }
 
 impl SourceLookup for Tilesets {
-    fn source(&self, tileset: &str) -> Option<&dyn TileRead> {
+    fn source(&self, tileset: &str) -> Option<&dyn TileSource> {
         self.get(tileset).map(|ts| ts.source.as_ref())
     }
 }

--- a/bbox-tile-server/src/service.rs
+++ b/bbox-tile-server/src/service.rs
@@ -62,6 +62,8 @@ pub enum ServiceError {
     CacheNotFound(String),
     #[error("Unknown format `{0}`")]
     UnknownFormat(String),
+    #[error("Tileset grid not found")] // default grid missing or z out of range
+    TilesetGridNotFound,
     #[error(transparent)]
     TileRegistryError(#[from] RegistryError),
     #[error(transparent)]
@@ -309,12 +311,13 @@ impl TileSet {
             .find(|tms| tms.id() == tms_id)
             .ok_or(RegistryError::TmsNotFound(tms_id.to_string()))
     }
-    pub fn default_grid(&self, zoom: u8) -> Option<&Tms> {
+    pub fn default_grid(&self, zoom: u8) -> Result<&Tms, ServiceError> {
         // TODO: guarantee grid sorted by minzoom
         self.tms
             .iter()
             .find(|grid| zoom >= grid.minzoom && zoom <= grid.maxzoom)
             .map(|grid| &grid.tms)
+            .ok_or(ServiceError::TilesetGridNotFound)
     }
     pub fn tile_format(&self) -> &Format {
         &self.format

--- a/bbox-tile-server/src/service.rs
+++ b/bbox-tile-server/src/service.rs
@@ -415,8 +415,8 @@ impl TileSet {
         }
     }
     /// TileJSON layer metadata (<https://github.com/mapbox/tilejson-spec>)
-    pub async fn tilejson(&self, base_url: &str) -> Result<TileJSON, ServiceError> {
-        let mut tilejson = self.source.tilejson(&self.format).await?;
+    pub async fn tilejson(&self, tms: &Tms, base_url: &str) -> Result<TileJSON, ServiceError> {
+        let mut tilejson = self.source.tilejson(tms, &self.format).await?;
         let suffix = tilejson
             .other
             .get("format")

--- a/bbox.toml
+++ b/bbox.toml
@@ -184,7 +184,8 @@ wms_proxy = { source = "gebco", layers = "gebco_latest" }
 
 [[tileset]]
 name = "rivers_lakes"
-tms = "LV95"
+[[tileset.tms]]
+id = "LV95"
 [tileset.map_service]
 project = "ne_extracts"
 suffix = "qgz"

--- a/docs/src/tile-server/running.md
+++ b/docs/src/tile-server/running.md
@@ -38,6 +38,7 @@ Options:
       --tileset <TILESET>      tile set name
       --minzoom <MINZOOM>      Minimum zoom level
       --maxzoom <MAXZOOM>      Maximum zoom level
+      --tms <TMS>              tile matrix set id
       --extent <EXTENT>        Extent minx,miny,maxx,maxy (in grid reference system)
       --tile-path <TILE_PATH>  Base directory for file store
       --s3-path <S3_PATH>      S3 path to upload to (e.g. s3://tiles)


### PR DESCRIPTION
Example with projection from WGS84:
```toml
[[grid]]
json = "EqualEarthGreenwichWGS84Quad.json"

[[tileset]]
name = "tracking"

[[tileset.tms]]
id = "EqualEarthGreenwichWGS84Quad"
maxzoom = 2

[[tileset.tms]]
id = "WebMercatorQuad"
minzoom = 3

[tileset.postgis]
datasource = "tracking"

[[tileset.postgis.layer]]
name = "waypoints"
geometry_field = "geom"
geometry_type = "POINT"
srid = 4326

[[tileset.postgis.layer.query]]
sql = """SELECT id, ts::TEXT, ST_Point(lon, lat, 4326) AS geom FROM gps.gpslog"""
```

Example with prepared tables:
```toml
[[grid]]
json = "EqualEarthGreenwichWGS84Quad.json"

[[tileset]]
name = "ocean"

[[tileset.tms]]
id = "EqualEarthGreenwichWGS84Quad"
maxzoom = 2

[[tileset.tms]]
id = "WebMercatorQuad"
minzoom = 3

[tileset.postgis]
datasource = "osmdb"

[[tileset.postgis.layer]]
geometry_field = "geom"
geometry_type = "POLYGON"
name = "ocean"
#srid = 8857 / 3857

[[tileset.postgis.layer.query]]
minzoom = 0
maxzoom = 2
sql = """SELECT "geom" FROM "eq"."ocean_low""""

[[tileset.postgis.layer.query]]
minzoom = 3
maxzoom = 9
sql = """SELECT "id","geom" FROM "merc"."ocean_low""""
```