### PR TITLE
Create web app scope based on url prefix

### DIFF
--- a/bbox-core/src/endpoints.rs
+++ b/bbox-core/src/endpoints.rs
@@ -78,25 +78,17 @@ pub fn absurl(req: &HttpRequest, path: &str) -> String {
             }
         })
         .unwrap_or("".to_string());
+    println!("REQBASE: {reqbase} PATH: {path}");
     format!("{}://{}{reqbase}{path}", conninfo.scheme(), conninfo.host())
 }
 
 /// landing page
-async fn index(ogcapi: web::Data<OgcApiInventory>, req: HttpRequest) -> HttpResponse {
+async fn index(ogcapi: web::Data<OgcApiInventory>, _req: HttpRequest) -> HttpResponse {
     // Make links absolute. Some clients (like OGC conformance tester) expect it.
-    let links = ogcapi
-        .landing_page_links
-        .iter()
-        .map(|link| {
-            let mut l = link.clone();
-            l.href = absurl(&req, &link.href);
-            l
-        })
-        .collect();
     let landing_page = CoreLandingPage {
         title: Some("BBOX OGC API".to_string()),
         description: Some("BBOX OGC API landing page".to_string()),
-        links,
+        links: ogcapi.landing_page_links.clone(),
     };
     HttpResponse::Ok().json(landing_page)
 }

--- a/bbox-core/src/endpoints.rs
+++ b/bbox-core/src/endpoints.rs
@@ -173,6 +173,11 @@ impl ServiceEndpoints for CoreService {
                     .route(web::get().to(index)),
             )
             .service(
+                web::resource("")
+                    .guard(JsonContentGuard)
+                    .route(web::get().to(index)),
+            )
+            .service(
                 web::resource("/conformance")
                     .guard(JsonContentGuard)
                     .route(web::get().to(conformance)),

--- a/bbox-core/src/endpoints.rs
+++ b/bbox-core/src/endpoints.rs
@@ -78,7 +78,6 @@ pub fn absurl(req: &HttpRequest, path: &str) -> String {
             }
         })
         .unwrap_or("".to_string());
-    println!("REQBASE: {reqbase} PATH: {path}");
     format!("{}://{}{reqbase}{path}", conninfo.scheme(), conninfo.host())
 }
 

--- a/bbox-core/src/service.rs
+++ b/bbox-core/src/service.rs
@@ -279,10 +279,10 @@ pub async fn run_service<T: OgcApiService + ServiceEndpoints + Sync + 'static>(
     let workers = core.workers();
     let server_addr = core.server_addr().to_string();
     let tls_config = core.tls_config();
-    let api_base = extract_api_base(core.web_config.public_server_url.as_deref());
+    let api_scope = extract_api_scope(core.web_config.public_server_url.as_deref());
     let mut server = HttpServer::new(move || {
         App::new().service(
-            web::scope(&api_base)
+            web::scope(&api_scope)
                 .configure(|cfg| core.register_endpoints(cfg))
                 .configure(|cfg| service.register_endpoints(cfg))
                 .wrap(
@@ -308,8 +308,8 @@ pub async fn run_service<T: OgcApiService + ServiceEndpoints + Sync + 'static>(
     server.workers(workers).run().await
 }
 
-pub fn extract_api_base(public_server_url: Option<&str>) -> String {
-    let api_base = if let Some(urlstr) = public_server_url {
+pub fn extract_api_scope(public_server_url: Option<&str>) -> String {
+    let api_scope = if let Some(urlstr) = public_server_url {
         let url = urlstr.parse::<Uri>().unwrap().path().to_string();
         if url == "/" {
             String::new()
@@ -319,5 +319,5 @@ pub fn extract_api_base(public_server_url: Option<&str>) -> String {
     } else {
         String::new()
     };
-    api_base
+    api_scope
 }

--- a/bbox-core/src/service.rs
+++ b/bbox-core/src/service.rs
@@ -309,7 +309,7 @@ pub async fn run_service<T: OgcApiService + ServiceEndpoints + Sync + 'static>(
 }
 
 pub fn extract_api_base(public_server_url: Option<&str>) -> String {
-    let api_base = if let Some(ref urlstr) = public_server_url {
+    let api_base = if let Some(urlstr) = public_server_url {
         let url = urlstr.parse::<Uri>().unwrap().path().to_string();
         if url == "/" {
             String::new()

--- a/bbox-feature-server/src/endpoints.rs
+++ b/bbox-feature-server/src/endpoints.rs
@@ -3,7 +3,6 @@ use crate::inventory::Inventory;
 use crate::service::FeatureService;
 use actix_web::{web, Error, HttpRequest, HttpResponse};
 use bbox_core::api::OgcApiInventory;
-use bbox_core::endpoints::absurl;
 use bbox_core::ogcapi::{ApiLink, CoreCollections};
 use bbox_core::service::ServiceEndpoints;
 use bbox_core::templates::{create_env_embedded, html_accepted, render_endpoint};
@@ -19,7 +18,7 @@ async fn collections(
 ) -> Result<HttpResponse, Error> {
     let collections = CoreCollections {
         links: vec![ApiLink {
-            href: absurl(&req, "/collections.json"),
+            href: format!("{}/collections.json", inventory.href_prefix()),
             rel: Some("self".to_string()),
             type_: Some("application/json".to_string()),
             title: Some("this document".to_string()),

--- a/bbox-map-server/src/inventory.rs
+++ b/bbox-map-server/src/inventory.rs
@@ -44,7 +44,10 @@ impl Inventory {
 
 impl WmsService {
     fn _project(&self) -> &str {
-        self.wms_path.split('/').last().expect("invalid wms_path")
+        self.wms_path
+            .split('/')
+            .next_back()
+            .expect("invalid wms_path")
     }
     #[allow(dead_code)]
     fn cap_request(&self) -> &str {

--- a/bbox-routing-server/src/ds.rs
+++ b/bbox-routing-server/src/ds.rs
@@ -58,7 +58,7 @@ impl RouterDs for GpkgLinesDs {
             let line = LineString::try_from(geom).unwrap();
             let mut coords = line.points();
             let src = coords.next().unwrap();
-            let dst = coords.last().unwrap();
+            let dst = coords.next_back().unwrap();
             let src_id = index.entry(src.x(), src.y());
             let dst_id = index.entry(dst.x(), dst.y());
             let weight = line.geodesic_length().round() as usize;

--- a/bbox-routing-server/src/service.rs
+++ b/bbox-routing-server/src/service.rs
@@ -63,9 +63,9 @@ impl OgcApiService for RoutingService {
             "http://www.opengis.net/spec/ogcapi-routes-1/1.0.0-draft.1/conf/oas30".to_string(),
         ]
     }
-    fn landing_page_links(&self, _api_base: &str) -> Vec<ApiLink> {
+    fn landing_page_links(&self, api_base: &str) -> Vec<ApiLink> {
         vec![ApiLink {
-            href: "/routes".to_string(),
+            href: format!("{api_base}/routes"),
             rel: Some("routes".to_string()),
             type_: Some("application/json".to_string()),
             title: Some("OGC API routes".to_string()),

--- a/bbox-server/src/main.rs
+++ b/bbox-server/src/main.rs
@@ -2,7 +2,7 @@ use actix_web::{middleware, middleware::Condition, web, App, HttpServer};
 use bbox_core::cli::CliArgs;
 use bbox_core::config::CoreServiceCfg;
 use bbox_core::service::{
-    extract_api_base, CoreService, OgcApiService, ServiceConfig, ServiceEndpoints,
+    extract_api_scope, CoreService, OgcApiService, ServiceConfig, ServiceEndpoints,
 };
 use log::info;
 use std::path::Path;
@@ -106,11 +106,11 @@ async fn run_service() -> std::io::Result<()> {
     let workers = core.workers();
     let server_addr = core.server_addr().to_string();
     let tls_config = core.tls_config();
-    let api_base = extract_api_base(core.web_config.public_server_url.as_deref());
+    let api_scope = extract_api_scope(core.web_config.public_server_url.as_deref());
     let mut server = HttpServer::new(move || {
         #[allow(unused_mut)]
         let mut app = App::new().service(
-            web::scope(&api_base)
+            web::scope(&api_scope)
                 .wrap(Condition::new(core.has_cors(), core.cors()))
                 .wrap(Condition::new(core.has_metrics(), core.middleware()))
                 .wrap(Condition::new(core.has_metrics(), core.metrics().clone()))

--- a/bbox-server/src/main.rs
+++ b/bbox-server/src/main.rs
@@ -1,4 +1,4 @@
-use actix_web::{middleware, middleware::Condition, App, HttpServer};
+use actix_web::{http::Uri, middleware, middleware::Condition, web, App, HttpServer};
 use bbox_core::cli::CliArgs;
 use bbox_core::config::CoreServiceCfg;
 use bbox_core::service::{CoreService, OgcApiService, ServiceConfig, ServiceEndpoints};
@@ -104,22 +104,34 @@ async fn run_service() -> std::io::Result<()> {
     let workers = core.workers();
     let server_addr = core.server_addr().to_string();
     let tls_config = core.tls_config();
+    let url_prefix = if let Some(ref urlstr) = core.web_config.public_server_url {
+        let url = urlstr.parse::<Uri>().unwrap().path().to_string();
+        if url == "/" {
+            String::new()
+        } else {
+            url
+        }
+    } else {
+        String::new()
+    };
     let mut server = HttpServer::new(move || {
         #[allow(unused_mut)]
-        let mut app = App::new()
-            .wrap(Condition::new(core.has_cors(), core.cors()))
-            .wrap(Condition::new(core.has_metrics(), core.middleware()))
-            .wrap(Condition::new(core.has_metrics(), core.metrics().clone()))
-            .wrap(middleware::Logger::default())
-            .wrap(middleware::Compress::default())
-            .configure(|cfg| core.register_endpoints(cfg))
-            .configure(bbox_core::static_assets::register_endpoints)
-            .configure(|cfg| map_service.register_endpoints(cfg))
-            .configure(|cfg| tile_service.register_endpoints(cfg))
-            .configure(|cfg| feature_service.register_endpoints(cfg))
-            .configure(|cfg| asset_service.register_endpoints(cfg))
-            .configure(|cfg| processes_service.register_endpoints(cfg))
-            .configure(|cfg| routing_service.register_endpoints(cfg));
+        let mut app = App::new().service(
+            web::scope(&url_prefix)
+                .wrap(Condition::new(core.has_cors(), core.cors()))
+                .wrap(Condition::new(core.has_metrics(), core.middleware()))
+                .wrap(Condition::new(core.has_metrics(), core.metrics().clone()))
+                .wrap(middleware::Logger::default())
+                .wrap(middleware::Compress::default())
+                .configure(|cfg| core.register_endpoints(cfg))
+                .configure(bbox_core::static_assets::register_endpoints)
+                .configure(|cfg| map_service.register_endpoints(cfg))
+                .configure(|cfg| tile_service.register_endpoints(cfg))
+                .configure(|cfg| feature_service.register_endpoints(cfg))
+                .configure(|cfg| asset_service.register_endpoints(cfg))
+                .configure(|cfg| processes_service.register_endpoints(cfg))
+                .configure(|cfg| routing_service.register_endpoints(cfg)),
+        );
 
         #[cfg(feature = "frontend")]
         {

--- a/bbox-tile-server/src/endpoints.rs
+++ b/bbox-tile-server/src/endpoints.rs
@@ -189,6 +189,7 @@ async fn tile_request(
 /// list of available tilesets
 // tiles
 async fn get_tile_sets_list(service: web::Data<TileService>) -> HttpResponse {
+    let href_prefix = service.href_prefix();
     let tile_set_items: Vec<TileSetItem> = service
         .tilesets
         .iter()
@@ -200,7 +201,7 @@ async fn get_tile_sets_list(service: web::Data<TileService>) -> HttpResponse {
                     rel: "http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme".to_string(),
                     r#type: Some("application/json".to_string()),
                     title: Some("Tile Matrix Set definition (as JSON)".to_string()),
-                    href: format!("/tileMatrixSets/{}", &grid_tms.id),
+                    href: format!("{href_prefix}/tileMatrixSets/{}", &grid_tms.id),
                     hreflang: None,
                     length: None,
                 }
@@ -215,7 +216,7 @@ async fn get_tile_sets_list(service: web::Data<TileService>) -> HttpResponse {
                         rel: "self".to_string(),
                         r#type: Some("application/json".to_string()),
                         title: Some(format!("Tileset metadata for {ts_name} (as JSON)")),
-                        href: format!("/tiles/{ts_name}"),
+                        href: format!("{href_prefix}/tiles/{ts_name}"),
                         hreflang: None,
                         length: None,
                     },
@@ -225,7 +226,7 @@ async fn get_tile_sets_list(service: web::Data<TileService>) -> HttpResponse {
                         title: Some(format!(
                             "Tileset metadata for {ts_name} (in TileJSON format)"
                         )),
-                        href: format!("/xyz/{ts_name}.json"),
+                        href: format!("{href_prefix}/xyz/{ts_name}.json"),
                         hreflang: None,
                         length: None,
                     },
@@ -234,7 +235,7 @@ async fn get_tile_sets_list(service: web::Data<TileService>) -> HttpResponse {
                         r#type: Some("application/vnd.mapbox-vector-tile".to_string()),
                         title: Some(format!("Tiles for {ts_name} (as MVT)")),
                         href: format!(
-                            "/map/tiles/{}/{{tileMatrix}}/{{tileRow}}/{{tileCol}}",
+                            "{href_prefix}/map/tiles/{}/{{tileMatrix}}/{{tileRow}}/{{tileCol}}",
                             &tms.tms.id
                         ),
                         hreflang: None,
@@ -277,13 +278,14 @@ async fn get_tile_set(
         })
         .collect();
 
+    let href_prefix = service.href_prefix();
     let tiling_scheme_links = ts.tms.iter().map(|grid| {
         let grid_tms = &grid.tms.tms;
         Link {
             rel: "http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme".to_string(),
             r#type: Some("application/json".to_string()),
             title: Some("Tile Matrix Set definition (as JSON)".to_string()),
-            href: format!("/tileMatrixSets/{}", &grid_tms.id),
+            href: format!("{href_prefix}/tileMatrixSets/{}", &grid_tms.id),
             hreflang: None,
             length: None,
         }
@@ -316,7 +318,7 @@ async fn get_tile_set(
                 rel: "self".to_string(),
                 r#type: Some("application/json".to_string()),
                 title: Some(format!("Tileset metadata for {tileset} (as JSON)")),
-                href: format!("/tiles/{tileset}"),
+                href: format!("{href_prefix}/tiles/{tileset}"),
                 hreflang: None,
                 length: None,
             },
@@ -324,7 +326,9 @@ async fn get_tile_set(
                 rel: "item".to_string(),
                 r#type: Some("application/vnd.mapbox-vector-tile".to_string()),
                 title: Some(format!("Tiles for {tileset} (as MVT)")),
-                href: format!("/xyz/{tileset}/{{tileMatrix}}/{{tileRow}}/{{tileCol}}.mvt"),
+                href: format!(
+                    "{href_prefix}/xyz/{tileset}/{{tileMatrix}}/{{tileRow}}/{{tileCol}}.mvt"
+                ),
                 hreflang: None,
                 length: None,
                 // TODO: "templated": true
@@ -341,6 +345,7 @@ async fn get_tile_set(
 // tileMatrixSets
 async fn get_tile_matrix_sets_list(service: web::Data<TileService>) -> HttpResponse {
     let grids = service.grids();
+    let href_prefix = service.href_prefix();
     let sets = TileMatrixSets {
         tile_matrix_sets: grids
             .iter()
@@ -353,7 +358,7 @@ async fn get_tile_matrix_sets_list(service: web::Data<TileService>) -> HttpRespo
                     rel: "http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme".to_string(),
                     r#type: Some("application/json".to_string()),
                     title: Some("Tile Matrix Set definition (as JSON)".to_string()),
-                    href: format!("/tileMatrixSets/{}", &grid.tms.id),
+                    href: format!("{href_prefix}/tileMatrixSets/{}", &grid.tms.id),
                     hreflang: None,
                     length: None,
                 }],

--- a/bbox-tile-server/src/service.rs
+++ b/bbox-tile-server/src/service.rs
@@ -24,6 +24,7 @@ use tilejson::TileJSON;
 #[derive(Clone)]
 pub struct TileService {
     pub(crate) tilesets: Tilesets,
+    base_url: String,
 }
 
 pub type Tilesets = HashMap<String, TileSet>;
@@ -103,7 +104,7 @@ impl OgcApiService for TileService {
     type CliArgs = ServiceArgs;
     type Metrics = NoMetrics;
 
-    async fn create(config: &Self::Config, _core_cfg: &CoreServiceCfg) -> Self {
+    async fn create(config: &Self::Config, core_cfg: &CoreServiceCfg) -> Self {
         let mut tilesets = HashMap::new();
 
         // Register custom grids
@@ -200,7 +201,15 @@ impl OgcApiService for TileService {
             };
             tilesets.insert(ts.name.clone(), tileset);
         }
-        TileService { tilesets }
+        let base_url = format!(
+            "{}/",
+            core_cfg
+                .public_server_url()
+                .as_deref()
+                .unwrap_or("")
+                .trim_end_matches('/')
+        );
+        TileService { tilesets, base_url }
     }
 
     async fn cli_run(&self, cli: &ArgMatches) -> bool {
@@ -324,6 +333,13 @@ impl TileService {
             }
         }
         None
+    }
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub fn href_prefix(&self) -> &str {
+        self.base_url.trim_end_matches('/')
     }
 }
 

--- a/bbox-tile-server/src/service.rs
+++ b/bbox-tile-server/src/service.rs
@@ -219,25 +219,29 @@ impl OgcApiService for TileService {
         }
     }
 
-    fn landing_page_links(&self, _api_base: &str) -> Vec<ApiLink> {
-        vec![
-            ApiLink {
-                href: "/tiles".to_string(),
-                rel: Some("http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector".to_string()),
-                type_: Some("application/json".to_string()),
-                title: Some("List of available vector features tilesets".to_string()),
-                hreflang: None,
-                length: None,
-            },
-            ApiLink {
-                href: "/tiles".to_string(),
-                rel: Some("http://www.opengis.net/def/rel/ogc/1.0/tilesets-map".to_string()),
-                type_: Some("application/json".to_string()),
-                title: Some("List of available map tilesets".to_string()),
-                hreflang: None,
-                length: None,
-            },
-        ]
+    fn landing_page_links(&self, api_base: &str) -> Vec<ApiLink> {
+        if self.tilesets.is_empty() {
+            vec![]
+        } else {
+            vec![
+                ApiLink {
+                    href: format!("{api_base}/tiles"),
+                    rel: Some("http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector".to_string()),
+                    type_: Some("application/json".to_string()),
+                    title: Some("List of available vector features tilesets".to_string()),
+                    hreflang: None,
+                    length: None,
+                },
+                ApiLink {
+                    href: format!("{api_base}/tiles"),
+                    rel: Some("http://www.opengis.net/def/rel/ogc/1.0/tilesets-map".to_string()),
+                    type_: Some("application/json".to_string()),
+                    title: Some("List of available map tilesets".to_string()),
+                    hreflang: None,
+                    length: None,
+                },
+            ]
+        }
     }
     fn conformance_classes(&self) -> Vec<String> {
         vec![


### PR DESCRIPTION
Set actix's web app scope using the url prefix extracted from the public_server_url config item, otherwise set it to blank.

eg.:

public_server_url = "http://localhost:8080/prefix" would result in a scope of "/prefix"



